### PR TITLE
fix: sync Composite values with Lottie schema

### DIFF
--- a/.changeset/tidy-repeaters-stack.md
+++ b/.changeset/tidy-repeaters-stack.md
@@ -1,0 +1,5 @@
+---
+"@lottie-animation-community/lottie-types": patch
+---
+
+fix(composite): correct repeater stacking values to `Below = 1` and `Above = 2`

--- a/src/constants/composite.ts
+++ b/src/constants/composite.ts
@@ -7,9 +7,9 @@ export type Composite = Helpers.Values<typeof Composite>;
 export namespace Composite {
   export type Value = Composite;
 
-  export const Above = 1;
+  export const Above = 2;
   export type Above = typeof Above;
-  export const Below = 2;
+  export const Below = 1;
   export type Below = typeof Below;
 
   /** @deprecated Use the {@linkcode Composite} namespace */

--- a/test/assert-constants.cjs
+++ b/test/assert-constants.cjs
@@ -38,8 +38,8 @@ module.exports = (lottie) => {
   // Spot-check every namespace against the Lottie spec values.
   assert.equal(BlendMode.Normal, 0);
   assert.equal(BlendMode.HardMix, 17);
-  assert.equal(Composite.Above, 1);
-  assert.equal(Composite.Below, 2);
+  assert.equal(Composite.Above, 2);
+  assert.equal(Composite.Below, 1);
   assert.equal(EffectType.Custom, 5);
   assert.equal(EffectType.Puppet, 34);
   assert.equal(EffectValueType.Slider, 0);

--- a/test/types.ts
+++ b/test/types.ts
@@ -24,6 +24,8 @@ const blendMember: BlendMode.Normal = BlendMode.Normal;
 const legacyBlend: BlendMode.Value = BlendMode.VALUE.NORMAL;
 const legacyBlendEnum: BlendMode.VALUE = BlendMode.VALUE.NORMAL;
 
+const compositeAbove: Composite.Above = 2;
+const compositeBelow: Composite.Below = 1;
 const legacyCompositeEnum: Composite.VALUE = Composite.VALUE.ABOVE;
 const legacyEffectEnum: EffectType.VALUE = EffectType.VALUE.TINT;
 const legacyEffectValueEnum: EffectValueType.VALUE =
@@ -75,6 +77,8 @@ void [
   blendMember,
   legacyBlend,
   legacyBlendEnum,
+  compositeAbove,
+  compositeBelow,
   legacyCompositeEnum,
   legacyEffectEnum,
   legacyEffectValueEnum,


### PR DESCRIPTION
## Summary

- correct `Composite` stacking values to `Below = 1` and `Above = 2`
- keep the modern namespace constants and deprecated `Composite.VALUE` aliases in sync
- add exact runtime and literal-type regression coverage
- add a patch changeset

## Context

The formal lottie-spec 1.0.1 schema does not yet define repeaters or `Composite`. This focused correction follows the exhaustive Lottie Docs schema and its corrected mapping: https://github.com/LottieFiles/lottie-docs/blob/main/schema/constants/composite.json

## Validation

- `yarn test`
- `yarn changeset status --since=origin/main`
- `git diff --check origin/main...HEAD`