### PR TITLE
ci: publish npm releases with OIDC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,20 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@v3
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Install Dependencies
         run: yarn
@@ -34,4 +40,3 @@ jobs:
           publish: yarn changelog:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,24 +17,29 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install Dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: yarn changelog:version
           publish: yarn changelog:publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,15 @@ jobs:
           - 18.x
           - 20.x
           - 22.x
+          - 24.x
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Summary

- replace the missing long-lived npm token with npm trusted publishing via GitHub OIDC
- grant only the GitHub and OIDC permissions required by the Changesets release job
- run releases on Node.js 24 with the npm registry configured and release caching disabled
- pin every GitHub Action to an immutable commit SHA and stop checkout from persisting credentials
- use Corepack and a frozen Yarn lockfile for deterministic release installs
- add Node.js 24 to CI and enable weekly Dependabot updates for GitHub Actions

## Context

The Changesets release after merging the version PR failed because neither `NPM_TOKEN` nor an OIDC identity was available:

- [Failed Release action](https://github.com/lottie/lottie-types/actions/runs/30072564455)

The repository contains package version `1.3.0`, while npm still has `1.2.0`. Once the npm trusted publisher is saved for `lottie/lottie-types` and `release.yml`, merging this PR should trigger publication of the pending version.

## Validation

- `git diff --check`
- `yarn prettier --check .github/dependabot.yml .github/workflows/release.yml .github/workflows/test.yml`
- `yarn install --frozen-lockfile`
- `yarn test`

## Follow-up settings

After the first successful OIDC publication:

- change npm publishing access to require 2FA and disallow traditional tokens
- activate protection for `main` with required pull requests, reviews, and test checks
- set the repository's default `GITHUB_TOKEN` permission to read-only
- review administrator access and enforce secure 2FA for the organization
