### PR TITLE
ci: fix Yarn install with npm OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.x
-          registry-url: https://registry.npmjs.org
+          # Omit registry-url because setup-node's auth placeholder requires
+          # NODE_AUTH_TOKEN, which is intentionally absent when publishing via OIDC.
           package-manager-cache: false
 
       - name: Enable Corepack


### PR DESCRIPTION
## Summary

- stop `setup-node` from generating an npm auth placeholder that Yarn 1 cannot resolve in tokenless OIDC workflows
- retain npm trusted publishing; npm uses its default registry
- document why `registry-url` must stay absent

## Context

Dependabot PR #23 upgraded `setup-node` to v7, which removed its dummy `NODE_AUTH_TOKEN` export. The subsequent release run failed during the frozen Yarn install:

- [Failed Release action](https://github.com/lottie/lottie-types/actions/runs/30075791948)
- [setup-node upgrade PR #23](https://github.com/lottie/lottie-types/pull/23)

When `registry-url` is set, `setup-node` writes `${NODE_AUTH_TOKEN}` into its generated npm configuration. Yarn 1 treats the missing environment variable as fatal. npm already defaults to `registry.npmjs.org`, and `changesets/action` detects OIDC independently.

Version 1.3.0 is already published; this change only restores future release runs.

## Validation

- `git diff --check`
- `yarn prettier --check .github/workflows/release.yml`
- `yarn install --frozen-lockfile`
- `yarn test`

No changeset is included because this only changes CI configuration.
